### PR TITLE
Json handler

### DIFF
--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -12,7 +12,7 @@ CONFIG_CONTRACT = Schema({
         Required('name'): str,
         Required('pattern'): str,
         Required('key_properties'): [str],
-        Required('format'): Any('csv', 'excel'),
+        Required('format'): Any('csv', 'excel', 'json'),
         Optional('search_prefix'): str,
         Optional('field_names'): [str],
         Optional('worksheet_name'): str,

--- a/tap_s3_csv/config.py
+++ b/tap_s3_csv/config.py
@@ -12,7 +12,7 @@ CONFIG_CONTRACT = Schema({
         Required('name'): str,
         Required('pattern'): str,
         Required('key_properties'): [str],
-        Required('format'): Any('csv', 'excel', 'json'),
+        Required('format'): Any('csv', 'excel', 'jsonl'),
         Optional('search_prefix'): str,
         Optional('field_names'): [str],
         Optional('worksheet_name'): str,

--- a/tap_s3_csv/format_handler.py
+++ b/tap_s3_csv/format_handler.py
@@ -26,3 +26,8 @@ def get_row_iterator(config, table_spec, s3_path):
     elif table_spec['format'] == 'excel':
         return tap_s3_csv.excel_handler.get_row_iterator(
             table_spec, file_handle)
+
+    elif table_spec['format'] == 'json':
+        return tap_s3_csv.json_handler.get_row_iterator(
+            table_spec,file_handle)
+    

--- a/tap_s3_csv/format_handler.py
+++ b/tap_s3_csv/format_handler.py
@@ -27,7 +27,7 @@ def get_row_iterator(config, table_spec, s3_path):
         return tap_s3_csv.excel_handler.get_row_iterator(
             table_spec, file_handle)
 
-    elif table_spec['format'] == 'json':
+    elif table_spec['format'] == 'jsonl':
         return tap_s3_csv.json_handler.get_row_iterator(
             table_spec,file_handle)
     

--- a/tap_s3_csv/json_handler.py
+++ b/tap_s3_csv/json_handler.py
@@ -4,7 +4,9 @@ import json
 def get_row_iterator(table_spec,file_handle):
     file_stream = codecs.iterdecode(file_handle._raw_stream, encoding='utf-8')
     for line in file_handle._raw_stream.readlines():
-        json_line = json.loads(line)
-        keys = list(json_line['subject'].keys())
-        yield json_line['subject'][keys[0]]
-        
+        outer_keys = json_line.keys()
+        if 'subject' in outer_keys:
+            keys = list(json_line['subject'].keys())
+            yield json_line['subject'][keys[0]]
+        else:
+            yield json_line

--- a/tap_s3_csv/json_handler.py
+++ b/tap_s3_csv/json_handler.py
@@ -4,6 +4,7 @@ import json
 def get_row_iterator(table_spec,file_handle):
     file_stream = codecs.iterdecode(file_handle._raw_stream, encoding='utf-8')
     for line in file_handle._raw_stream.readlines():
+        json_line = json.loads(line)
         outer_keys = json_line.keys()
         if 'subject' in outer_keys:
             keys = list(json_line['subject'].keys())

--- a/tap_s3_csv/json_handler.py
+++ b/tap_s3_csv/json_handler.py
@@ -7,3 +7,4 @@ def get_row_iterator(table_spec,file_handle):
         json_line = json.loads(line)
         keys = list(json_line['subject'].keys())
         yield json_line['subject'][keys[0]]
+        

--- a/tap_s3_csv/json_handler.py
+++ b/tap_s3_csv/json_handler.py
@@ -1,0 +1,9 @@
+import codecs
+from io import TextIOWrapper
+import json
+def get_row_iterator(table_spec,file_handle):
+    file_stream = codecs.iterdecode(file_handle._raw_stream, encoding='utf-8')
+    for line in file_handle._raw_stream.readlines():
+        json_line = json.loads(line)
+        keys = list(json_line['subject'].keys())
+        yield json_line['subject'][keys[0]]

--- a/tap_s3_csv/json_handler.py
+++ b/tap_s3_csv/json_handler.py
@@ -5,9 +5,4 @@ def get_row_iterator(table_spec,file_handle):
     file_stream = codecs.iterdecode(file_handle._raw_stream, encoding='utf-8')
     for line in file_handle._raw_stream.readlines():
         json_line = json.loads(line)
-        outer_keys = json_line.keys()
-        if 'subject' in outer_keys:
-            keys = list(json_line['subject'].keys())
-            yield json_line['subject'][keys[0]]
-        else:
-            yield json_line
+        yield json_line


### PR DESCRIPTION
adding JSON format data handler when data comes from S3 in JSON format. The JSON handler can handle the immidiate schema that comes in, but goes a step further when finds "subject" key that satisfy our braintree webhook tap, i.e braintree_daily tap's schema which has the hierarchy of
```
{
  'subject':
    {
       'disbursement' or 'subscription' or 'dispute' or 'paypal_account':
        {
          key1:value1
          key2:value2
          key3:value3
          .
          .
        }
    }
}
```
Doing this extra step so that this does not get expensive to post process in transforms when there is a lot more data